### PR TITLE
Add pretty print with rich table to a typer based cli app

### DIFF
--- a/scripts/parse-results.py
+++ b/scripts/parse-results.py
@@ -1,40 +1,67 @@
 #!/bin/env python3
-import argparse
-import sys
+import typer
 from pathlib import Path
+from rich.console import Console
+from rich.table import Table
 
 from junitparser import JUnitXml
 
-def parse_args():
-    parser = argparse.ArgumentParser(description='parse junit result.')
-    parser.add_argument('result_dir', type=str, help='result dir')
-    parser.add_argument('--exit-on-fail', dest='exit_on_fail', action='store_true')
 
-    args = parser.parse_args()
-    return args
+app = typer.Typer()
+err_console = Console(stderr=True)
+console = Console()
+table = Table(title="Compliance Error result", show_lines=True)
 
 
-def main(root_dir, exit_on_fail):
-    dir_path = Path(root_dir)
+@app.command()
+def parse(
+    result_dir: str = typer.Option(
+        ...,
+        help="Directory with the result to parse"),
+    exit_on_fail: bool = typer.Option(
+        False,
+        help="Force failing with exit code 1 for CI pipeline"),
+    pretty_print: bool = typer.Option(
+        False,
+        help="Print with a better formatting")
+    ):
+    """
+    Parse junit result.
+    """
+    dir_path = Path(result_dir)
     if not dir_path.exists():
-        print(f"test dir '{root_dir}' should exist")
-        sys.exit(1)
+        err_console.print(f"test dir '{result_dir}' should exist")
+        raise typer.Exit()
 
     failed_cases = []
+    failed_tuples = []
 
     for junit_test in dir_path.glob("**/**/TEST-org.opengis.cite.*.xml"):
         test_xml = JUnitXml.fromfile(str(junit_test))
         failed = [case.message for suite in test_xml for case in suite if case.type == "java.lang.Throwable"]
+        failed_tuples += [
+            (
+                junit_test.name,
+                test_xml.name,
+                case.message
+            ) for suite in test_xml for case in suite if case.type == "java.lang.Throwable"]
         if failed:
             failed_cases += [f"### {test_xml.name}"] + failed + [""]
 
-    print("\n".join(failed_cases))
+    if pretty_print:
+        table.add_column("Case Name", justify="right", style="cyan", no_wrap=False)
+        table.add_column("Error", justify="right", style="red", no_wrap=False)
+        table.add_column("File", justify="right", style="magenta", no_wrap=False)
+        # case_iter = iter(failed_cases)
+        # cases = zip(case_iter, case_iter, case_iter)
+        for case in failed_tuples:
+            table.add_row(case[1], case[2], str(case[0]))
+        console.print(table)
+    else:
+        typer.secho("\n".join(failed_cases), fg=typer.colors.RED)
     if failed_cases and exit_on_fail:
-        sys.exit(1)
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    result_dir = args.result_dir
-    exit_on_fail = args.exit_on_fail
-    main(result_dir, exit_on_fail)
+    app()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,3 @@
 junitparser==2.7.0
+typer[all]
+typer-cli

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -19,9 +19,15 @@ if [[ $* == *--exitOnFail* ]];then
   EXIT_ON_FAIL="--exit-on-fail"
 fi
 
+PRETTY_PRINT=""
+if [[ $* == *--prettyPrint* ]];then
+  PRETTY_PRINT="--pretty-print"
+fi
+
 exec 5>&1 # capture output command and write to stdout see https://stackoverflow.com/a/16292136
 output=$(java -jar /opt/ets-ogcapi-features10-aio.jar "$@"|tee /dev/fd/5)
 output_dir=$(grep "Test results" <<< "$output" | cut -d: -f3 | xargs dirname)
 echo "output saved in ${output_dir}"
 echo "$EXIT_ON_FAIL"
-python3 /src/parse-results.py "${output_dir}" ${EXIT_ON_FAIL}
+echo "$PRETTY_PRINT"
+python3 /src/parse-results.py "${output_dir}" ${EXIT_ON_FAIL} ${PRETTY_PRINT}


### PR DESCRIPTION
# Info

This adds Typer dependency for the CLI application and a pretty print option for having better formatting with a table based on Rich. Example:

`python3 parse-results.py --result-dir ../../ets-ogcapi-features10/output --pretty-print --exit-on-fail`

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/560676/178854861-3120f8e8-b92d-4496-ab2b-dd01ff875afe.png">
