### PR TITLE
Upgrade OGC API Features validator from 1.7 to 1.9 + also fail on errored testcases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/maven:3-eclipse-temurin-8
+FROM docker.io/maven:3-eclipse-temurin-21
 
 ARG REPO=https://github.com/opengeospatial/ets-ogcapi-features10.git
-ARG REPO_REF="tags/1.7"
+ARG REPO_REF="tags/1.9"
 
 WORKDIR /src
 RUN git clone ${REPO} . && git checkout ${REPO_REF}
@@ -16,10 +16,11 @@ RUN apt update && apt install -y python3 \
 WORKDIR /src
 COPY scripts /src
 
+RUN python3 -m pip config set global.break-system-packages true
 RUN python3 -m pip install -r requirements.txt
 LABEL AUTHOR="pdok@kadaster.nl"
 # set correct timezone
-ENV TZ Europe/Amsterdam
+ENV TZ=Europe/Amsterdam
 
 COPY --from=0 /src/target/ets-ogcapi-features10-aio.jar /opt/ets-ogcapi-features10-aio.jar
 ENTRYPOINT ["bash", "/src/startup.sh"]

--- a/scripts/parse-results.py
+++ b/scripts/parse-results.py
@@ -196,7 +196,7 @@ def main(result_dir, service_url, pretty_print, exit_on_fail):
             console.print("# SKIPPED TEST CASES\n", style="yellow")
             console.print("\n".join(skipped_cases), style="yellow")
 
-    if failed_cases and exit_on_fail:
+    if (failed_cases or errored_cases) and exit_on_fail:
         exit(1)
 
 


### PR DESCRIPTION
# Description

- Upgrade OGC API Features validator from 1.7 to 1.9 
- Also fail on errored testcases

Important: merge once https://github.com/PDOK/gokoala/pull/276/commits/69e4d4b4dcbaa2193f8e0370d5a416cfb99249fe is merged.

## Type of change

- Minor change (typo, formatting, version bump)
- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR